### PR TITLE
Added Debian to first paragraph description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Want to update your computer software? The update command is for you.
 
 When you run `update` the command will run many software updates and upgrades:
 
-  * Linux: Ubuntu `apt`, RedHat `yum`, Arch `yay`, Fedora `dnf`, etc.
+  * Linux: Debian/Ubuntu `apt`, RedHat `yum`, Arch `yay`, Fedora `dnf`, etc.
   * macOS: `softwareupdate`, Homebrew `brew`, Mac App Store `mas`, etc.
   * tooling: Node `npm`, Python `pip`, Rust `cargo`, Ruby `gem`, Atom `apm`, etc.
   * source code management: `git pull`, `hg pull`, etc.


### PR DESCRIPTION
Since Ubuntu is derived from Debian and has inherited its package manager from there, I felt as if Debian should be mentioned alongside Ubuntu in the top level description - after all, it is mentioned further down the README.