### PR TITLE
FIX: add detection for homebrew installation of asdf

### DIFF
--- a/bin/update-asdf
+++ b/bin/update-asdf
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -euf
 
+# When asdf is installed via homebrew it does not allow self-update via asdf
+if brew list --formula | grep -q '^asdf$'; then
+    exit 0
+fi
+
 # asdf-vm: manage multiple runtime versions with a single CLI tool
 if command -v asdf >/dev/null 2>&1; then
     # asdf has multiple ways that may be able to do updates,


### PR DESCRIPTION
When asdf has been installed via home-brew, it will fail out if you attempt to self update the way `bin/update-asdf` does.

```bash
$ asdf update
Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.
```

This PR adds an additional check to determine if asdf was installed via homebrew. If it was, the script will exit quietly.